### PR TITLE
Couldn't login after logout. Can now.

### DIFF
--- a/templates/login-panel.html
+++ b/templates/login-panel.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <div xmlns="http://www.w3.org/1999/xhtml" class="modal fade" id="loginModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
     <div class="modal-dialog">
-        <form method="POST" class="form-horizontal">
+        <form action="./" method="POST" class="form-horizontal">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>


### PR DESCRIPTION
After logout, subsequent logins failed.
Adding action="./" to the form element clears the logout=true parameter allowing subsequent logins to succeed.
I manually typed the code in so I haven't fully tested the original but I am proposing this change just in case it may be useful.